### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-native": "^0.46.1"
   },
   "dependencies": {
-    "react-native-autocomplete-input": "^3.3.1"
+    "react-native-autocomplete-input": "^3.6.0"
   },
   "peerDependencies": {}
 }


### PR DESCRIPTION
Upgrades the react-native-autocomplete-input package, fixing a compatibility issue with React Native 0.57

See https://github.com/l-urence/react-native-autocomplete-input/issues/104