### PR TITLE
Correction of the keyExtractor warning in the autocomplete

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ export default class AutoTags extends Component {
           this.renderTags()}
         <Autocomplete
           data={data}
+          keyExtractor={(item, index) => index.toString()}
           controlled={true}
           placeholder={this.props.placeholder}
           defaultValue={query}


### PR DESCRIPTION
The react-native-autocomplete-input package was created waiting for the keyExtractor parameter to pass, since the package uses the react-native FlatList component. When using lib
react-native-tag-autocomplete, a warning is displayed for the lack of this property in lib's Autocomplete component
react-native-tag-autocomplete