### PR TITLE
filterData first check if overwrite from props

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,11 @@ export default class AutoTags extends Component {
   };
 
   filterData = query => {
-    if (!query || query.trim() == "" || !this.props.suggestions) {
-      return;
-    }
     if (this.props.filterData) {
       return this.props.filterData(query);
+    }
+    if (!query || query.trim() == "" || !this.props.suggestions) {
+      return;
     }
     let suggestions = this.props.suggestions;
     let results = [];


### PR DESCRIPTION
On filterData method first, it should check if there is an overwrite of the method, and after that do the default checks. So it can be overwritten even for an empty query.