### PR TITLE
Upgrades react-native-autocomplete-input dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-native": "^0.46.1"
   },
   "dependencies": {
-    "react-native-autocomplete-input": "^4.1.0"
+    "react-native-autocomplete-input": "^5.5.0"
   },
   "peerDependencies": {}
 }


### PR DESCRIPTION
This PR upgrades the `react-native-autocomplete-input` dependency in order to prevent the following error :

```
 ERROR  Invariant Violation: ViewPropTypes has been removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'., js engine: hermes
```